### PR TITLE
fix: 修正 /orders/me 路由順序，解決 404 錯誤

### DIFF
--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -28,6 +28,22 @@ const generateOrderId = () => {
   return `${datePart}${randomPart}`;
 };
 
+// GET my orders (Logged-in User) - MUST be before /:id to avoid matching "me" as an id
+router.get("/me", requireSupabaseAuth, async (req: Request, res: Response) => {
+  const user = (req as AuthenticatedRequest).user;
+  const { data, error } = await supabase
+    .from("orders")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Supabase error (GET /me):", error);
+    return res.status(500).json({ message: "取得個人訂單失敗" });
+  }
+  res.json(data);
+});
+
 // GET single order by order_id or id (Public access allowed for confirmation page reliability)
 router.get("/:id", async (req: Request, res: Response) => {
   const { id } = req.params;
@@ -86,8 +102,9 @@ router.get("/:id", async (req: Request, res: Response) => {
   res.json(responseData);
 });
 
-// Middleware: Require Supabase Auth for all OTHER order routes
+// Middleware: Require Supabase Auth for all routes defined AFTER this point
 router.use(requireSupabaseAuth);
+
 
 // GET all orders (Admin Only)
 router.get("/", requireAdmin, async (_req: Request, res: Response) => {
@@ -98,22 +115,6 @@ router.get("/", requireAdmin, async (_req: Request, res: Response) => {
     return res.status(500).json({ message: "取得訂單資料失敗" });
   }
 
-  res.json(data);
-});
-
-// GET my orders (Logged-in User)
-router.get("/me", async (req: Request, res: Response) => {
-  const user = (req as AuthenticatedRequest).user;
-  const { data, error } = await supabase
-    .from("orders")
-    .select("*")
-    .eq("user_id", user.id)
-    .order("created_at", { ascending: false });
-
-  if (error) {
-    console.error("Supabase error (GET /me):", error);
-    return res.status(500).json({ message: "取得個人訂單失敗" });
-  }
   res.json(data);
 });
 


### PR DESCRIPTION
**✅ 路由匹配流程**
請求 /orders/me
    ↓
匹配到 GET /me（第 32 行）✅
    ↓
執行 requireSupabaseAuth middleware
    ↓
返回使用者的訂單列表
請求 /orders/123456
    ↓
不匹配 GET /me
    ↓
匹配到 GET /:id（第 48 行）✅
    ↓
返回特定訂單資料（公開訪問）
**🎯 關鍵優點**
✅ /me 在 /:id 之前 - Express 會優先匹配具體路徑
✅ /me 使用 requireSupabaseAuth - 確保只有登入使用者可以訪問
✅ /:id 不需驗證 - 訂單確認頁面可以公開訪問
✅ 沒有重複的路由定義 - 每個路由只定義一次